### PR TITLE
fix: JfsObjects.CompleteMultipartUpload

### DIFF
--- a/cmd/gateway/juicefs/gateway-juicefs.go
+++ b/cmd/gateway/juicefs/gateway-juicefs.go
@@ -1010,7 +1010,7 @@ func (n *JfsObjects) CompleteMultipartUpload(ctx context.Context, bucket, object
 	var total uint64
 	for _, part := range parts {
 		p := n.ppath(bucket, uploadID, strconv.Itoa(part.PartNumber))
-		copied, eno := n.fs.CopyFileRange(mctx, p, 0, tmp, total, 1<<30)
+		copied, eno := n.fs.CopyFileRange(mctx, p, 0, tmp, total, 1<<30*5)
 		if eno != 0 {
 			err = jfsToObjectErr(ctx, eno, bucket, object, uploadID)
 			logger.Errorf("merge parts: %s", err)


### PR DESCRIPTION
## Description
Increased max size of part to 5Gb in CompleteMultipartUpload

## Motivation and Context
I've caught bug when tested server side copy with rclone. Rclone has default copy cutoff [4.656Gi](https://rclone.org/s3/#s3-copy-cutoff). During CompleteMultipartUpload gateway ignores size of parts and doesn't consider globalMaxPartSize (5GiB) and copies 1Gb max of each part.

## How to test this PR?


## Types of changes
- [*] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
