### PR TITLE
feat: enable basic LDAP functionalities

### DIFF
--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1835,17 +1835,40 @@ func (sys *IAMSys) ListGroups() (r []string, err error) {
 		return r, errServerNotInitialized
 	}
 
-	if sys.usersSysType != MinIOUsersSysType {
-		return nil, errIAMActionNotAllowed
+	switch sys.usersSysType {
+	case MinIOUsersSysType:
+		return sys.listMinIOGroups()
+	case LDAPUsersSysType:
+		return sys.listLDAPGroups()
+	default:
+		return r, errIAMActionNotAllowed
 	}
+}
 
+func (sys *IAMSys) listMinIOGroups() ([]string, error) {
 	<-sys.configLoaded
 
 	sys.Lock()
 	defer sys.Unlock()
 
-	r = make([]string, 0, len(sys.iamGroupsMap))
+	r := make([]string, 0, len(sys.iamGroupsMap))
 	for k := range sys.iamGroupsMap {
+		r = append(r, k)
+	}
+
+	return r, nil
+}
+
+func (sys *IAMSys) listLDAPGroups() ([]string, error) {
+	<-sys.configLoaded
+
+	policyMap := make(map[string]MappedPolicy)
+	if err := sys.store.loadMappedPolicies(context.Background(), stsUser, true, policyMap); err != nil {
+		return nil, err
+	}
+
+	r := make([]string, 0, len(policyMap))
+	for k := range policyMap {
 		r = append(r, k)
 	}
 

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -2159,13 +2159,13 @@ func (sys *IAMSys) IsAllowedLDAPSTS(args iampolicy.Args, parentUser string) bool
 	}
 
 	// Check policy for this LDAP user.
-	ldapPolicies, err := sys.PolicyDBGet(parentUser, false, args.Groups...)
-	if err != nil {
-		return false
-	}
-
+	ldapPolicies, _ := sys.policyDBGet(args.AccountName, false)
 	if len(ldapPolicies) == 0 {
-		return false
+		parentPolicies, err := sys.PolicyDBGet(parentUser, false, args.Groups...)
+		if err != nil {
+			return false
+		}
+		ldapPolicies = parentPolicies
 	}
 
 	var availablePolicies []iampolicy.Policy

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -963,6 +963,13 @@ func (sys *IAMSys) listLDAPUsers() (map[string]madmin.UserInfo, error) {
 		}
 	}
 
+	// remove temp users created via STS
+	for k, v := range sys.iamUsersMap {
+		if v.IsTemp() || v.IsServiceAccount() {
+			delete(users, k)
+		}
+	}
+
 	return users, nil
 }
 

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -912,10 +912,17 @@ func (sys *IAMSys) ListUsers() (map[string]madmin.UserInfo, error) {
 		return nil, errServerNotInitialized
 	}
 
-	if sys.usersSysType != MinIOUsersSysType {
+	switch sys.usersSysType {
+	case MinIOUsersSysType:
+		return sys.listMinIOUsers()
+	case LDAPUsersSysType:
+		return sys.listLDAPUsers()
+	default:
 		return nil, errIAMActionNotAllowed
 	}
+}
 
+func (sys *IAMSys) listMinIOUsers() (map[string]madmin.UserInfo, error) {
 	<-sys.configLoaded
 
 	sys.Lock()
@@ -934,6 +941,25 @@ func (sys *IAMSys) ListUsers() (map[string]madmin.UserInfo, error) {
 					return madmin.AccountDisabled
 				}(),
 			}
+		}
+	}
+
+	return users, nil
+}
+
+func (sys *IAMSys) listLDAPUsers() (map[string]madmin.UserInfo, error) {
+	<-sys.configLoaded
+
+	policyMap := make(map[string]MappedPolicy)
+	if err := sys.store.loadMappedPolicies(context.Background(), stsUser, false, policyMap); err != nil {
+		return nil, err
+	}
+
+	users := make(map[string]madmin.UserInfo)
+	for k, v := range policyMap {
+		users[k] = madmin.UserInfo{
+			PolicyName: v.Policies,
+			Status:     madmin.AccountEnabled,
 		}
 	}
 

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -1034,6 +1034,7 @@ func (sys *IAMSys) GetUserInfo(name string) (u madmin.UserInfo, err error) {
 		}
 		return madmin.UserInfo{
 			PolicyName: mappedPolicy.Policies,
+			Status:     madmin.AccountEnabled,
 			MemberOf:   memberships.ToSlice(),
 		}, nil
 	}

--- a/cmd/jwt.go
+++ b/cmd/jwt.go
@@ -62,6 +62,9 @@ func authenticateJWTUsers(accessKey, secretKey string, expiry time.Duration) (st
 	claims := xjwt.NewMapClaims()
 	claims.SetExpiry(expiresAt)
 	claims.SetAccessKey(cred.AccessKey)
+	if cred.ParentUser != "" {
+		claims.SetLDAPUser(cred.ParentUser)
+	}
 
 	jwt := jwtgo.NewWithClaims(jwtgo.SigningMethodHS512, claims)
 	return jwt.SignedString([]byte(secret))
@@ -100,9 +103,7 @@ func authenticateLDAPUsersForJWT(username, password string, expiredAt time.Time)
 	cred.ParentUser = ldapUserDN
 	cred.Groups = ldapGroups
 
-	// Set the newly generated credentials, policyName is empty on purpose
-	// LDAP policies are applied automatically using their ldapUser, ldapGroups
-	// mapping.
+	// Set the newly generated credentials, ensure that policies are fixed during the session.
 	if err = globalIAMSys.SetTempUser(cred.AccessKey, cred, strings.Join(ldapPolicies, ",")); err != nil {
 		return auth.Credentials{}, "", errAuthentication
 	}

--- a/cmd/jwt.go
+++ b/cmd/jwt.go
@@ -51,34 +51,85 @@ var (
 )
 
 func authenticateJWTUsers(accessKey, secretKey string, expiry time.Duration) (string, error) {
-	passedCredential, err := auth.CreateCredentials(accessKey, secretKey)
+	expiresAt := UTCNow().Add(expiry)
+
+	cred, secret, err := authenticateUsersForJWT(accessKey, secretKey, expiresAt)
 	if err != nil {
 		return "", err
-	}
-	expiresAt := UTCNow().Add(expiry)
-	return authenticateJWTUsersWithCredentials(passedCredential, expiresAt)
-}
-
-func authenticateJWTUsersWithCredentials(credentials auth.Credentials, expiresAt time.Time) (string, error) {
-	serverCred := globalActiveCred
-	if serverCred.AccessKey != credentials.AccessKey {
-		var ok bool
-		serverCred, ok = globalIAMSys.GetUser(credentials.AccessKey)
-		if !ok {
-			return "", errInvalidAccessKeyID
-		}
-	}
-
-	if !serverCred.Equal(credentials) {
-		return "", errAuthentication
 	}
 
 	claims := xjwt.NewMapClaims()
 	claims.SetExpiry(expiresAt)
-	claims.SetAccessKey(credentials.AccessKey)
+	claims.SetAccessKey(cred.AccessKey)
 
 	jwt := jwtgo.NewWithClaims(jwtgo.SigningMethodHS512, claims)
-	return jwt.SignedString([]byte(serverCred.SecretKey))
+	return jwt.SignedString([]byte(secret))
+}
+
+func authenticateUsersForJWT(accessKey, secretKey string, expiredAt time.Time) (auth.Credentials, string, error) {
+	if globalIAMSys.usersSysType == LDAPUsersSysType {
+		return authenticateLDAPUsersForJWT(accessKey, secretKey, expiredAt)
+	}
+	return authenticateMinIOUsersForJWT(accessKey, secretKey)
+}
+
+func authenticateLDAPUsersForJWT(username, password string, expiredAt time.Time) (auth.Credentials, string, error) {
+	ldapUserDN, ldapGroups, err := globalLDAPConfig.Bind(username, password)
+	if err != nil {
+		return auth.Credentials{}, "", errAuthentication
+	}
+
+	// Check if this user or their groups have a policy applied.
+	ldapPolicies, _ := globalIAMSys.PolicyDBGet(ldapUserDN, false, ldapGroups...)
+	if len(ldapPolicies) == 0 {
+		return auth.Credentials{}, "", errInvalidAccessKeyID
+	}
+
+	m := map[string]interface{}{
+		expClaim: expiredAt.Unix(),
+		ldapUser: ldapUserDN,
+	}
+
+	secret := globalActiveCred.SecretKey
+	cred, err := auth.GetNewCredentialsWithMetadata(m, secret)
+	if err != nil {
+		return auth.Credentials{}, "", errAuthentication
+	}
+
+	cred.ParentUser = ldapUserDN
+	cred.Groups = ldapGroups
+
+	// Set the newly generated credentials, policyName is empty on purpose
+	// LDAP policies are applied automatically using their ldapUser, ldapGroups
+	// mapping.
+	if err = globalIAMSys.SetTempUser(cred.AccessKey, cred, ""); err != nil {
+		return auth.Credentials{}, "", errAuthentication
+	}
+
+	// Notify all other MinIO peers to reload temp users
+	for _, nerr := range globalNotificationSys.LoadUser(cred.AccessKey, true) {
+		if nerr.Err != nil {
+			return auth.Credentials{}, "", errAuthentication
+		}
+	}
+
+	return cred, secret, nil
+}
+
+func authenticateMinIOUsersForJWT(accessKey, secretKey string) (auth.Credentials, string, error) {
+	serverCred := globalActiveCred
+	if serverCred.AccessKey != accessKey {
+		var ok bool
+		serverCred, ok = globalIAMSys.GetUser(accessKey)
+		if !ok {
+			return auth.Credentials{}, "", errInvalidAccessKeyID
+		}
+	}
+
+	if serverCred.AccessKey != serverCred.AccessKey && serverCred.SecretKey != secretKey {
+		return auth.Credentials{}, "", errAuthentication
+	}
+	return serverCred, serverCred.SecretKey, nil
 }
 
 func authenticateNode(accessKey, secretKey, audience string) (string, error) {
@@ -119,7 +170,6 @@ func webTokenCallback(claims *xjwt.MapClaims) ([]byte, error) {
 		return nil, errInvalidAccessKeyID
 	}
 	return []byte(cred.SecretKey), nil
-
 }
 
 func isAuthTokenValid(token string) bool {

--- a/cmd/jwt.go
+++ b/cmd/jwt.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	jwtgo "github.com/dgrijalva/jwt-go"
@@ -102,7 +103,7 @@ func authenticateLDAPUsersForJWT(username, password string, expiredAt time.Time)
 	// Set the newly generated credentials, policyName is empty on purpose
 	// LDAP policies are applied automatically using their ldapUser, ldapGroups
 	// mapping.
-	if err = globalIAMSys.SetTempUser(cred.AccessKey, cred, ""); err != nil {
+	if err = globalIAMSys.SetTempUser(cred.AccessKey, cred, strings.Join(ldapPolicies, ",")); err != nil {
 		return auth.Credentials{}, "", errAuthentication
 	}
 

--- a/cmd/jwt/parser.go
+++ b/cmd/jwt/parser.go
@@ -78,6 +78,7 @@ type StandardClaims struct {
 // MapClaims - implements custom unmarshaller
 type MapClaims struct {
 	AccessKey string `json:"accessKey,omitempty"`
+	LDAPUser  string `json:"ldapUser,omitempty"`
 	jwtgo.MapClaims
 }
 
@@ -160,6 +161,12 @@ func (c *MapClaims) SetExpiry(t time.Time) {
 func (c *MapClaims) SetAccessKey(accessKey string) {
 	c.MapClaims["sub"] = accessKey
 	c.MapClaims["accessKey"] = accessKey
+}
+
+// SetLDAPUser sets parent user dn as custom
+// "ldapUser" field.
+func (c *MapClaims) SetLDAPUser(ldapUser string) {
+	c.MapClaims["ldapUser"] = ldapUser
 }
 
 // Valid - implements https://godoc.org/github.com/dgrijalva/jwt-go#Claims compatible
@@ -317,6 +324,7 @@ func ParseWithClaims(tokenStr string, claims *MapClaims, fn func(*MapClaims) ([]
 				jwtgo.ValidationErrorClaimsInvalid)
 		}
 	}
+	claims.LDAPUser, _ = claims.Lookup("ldapUser")
 
 	// Lookup key from claims, claims may not be valid and may return
 	// invalid key which is okay as the signature verification will fail.


### PR DESCRIPTION
## Description

LDAP support exists in Apache-2.0 MinIO, but it's lacking some key functionalities. In this PR we add:
- [x] support for listing valid users with LDAP;
- [x] support for STS policies with LDAP;
- [x] support for logging into the browser with LDAP STS;
- [x] support for listing groups with LDAP.

This PR is the core of unblocking https://github.com/juicedata/juicefs/issues/5368

## Motivation and Context
 
See https://github.com/juicedata/juicefs/issues/5368

## How to test this PR?

Suppose you have an LDAP server running on `ldaps://ldap.example.com:636` with root DN `dc=example,dc=com`, and a test FS `sqlite3://test.db`.

```
# Build
export MINIO_IDENTITY_LDAP_GROUP_SEARCH_BASE_DN="ou=groups,dc=example,dc=com"
export MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER="(&(objectClass=groupOfUniqueNames)(uniqueMember=%d))"
export MINIO_IDENTITY_LDAP_LOOKUP_BIND_DN="cn=juicefs,ou=services,dc=example,dc=com"
export MINIO_IDENTITY_LDAP_LOOKUP_BIND_PASSWORD="jfs-password"
export MINIO_IDENTITY_LDAP_SERVER_ADDR="ldap.example.com:636"
export MINIO_IDENTITY_LDAP_USER_DN_SEARCH_BASE_DN="ou=users,dc=example,dc=com"
export MINIO_IDENTITY_LDAP_USER_DN_SEARCH_FILTER="(&(objectClass=inetOrgPerson)(uid=%s))"
export MINIO_ROOT_USER="admin"
export MINIO_ROOT_PASSWORD="juicefs"
juicefs gateway sqlite3://test.db localhost:9000 --multi-buckets
```

You can use the browser to log into the gateway via http://localhost:9000/minio.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
